### PR TITLE
Google Cloud Monitoring Update

### DIFF
--- a/pkg/command/query.go
+++ b/pkg/command/query.go
@@ -12,7 +12,7 @@ type QueryType int
 
 const (
 	SQL = iota
-	Prometheus
+	PromQL
 )
 
 type Query struct {
@@ -84,7 +84,7 @@ func (q QueryManager) Put(file string) error {
 		query = Query{
 			Name: name,
 			Raw:  string(rawQuery),
-			Type: Prometheus,
+			Type: PromQL,
 		}
 	} else {
 		return fmt.Errorf("query file: %s is not supported", file)

--- a/pkg/grafsdk/meta.go
+++ b/pkg/grafsdk/meta.go
@@ -76,3 +76,9 @@ type Datasource struct {
 	Version           int              `json:"version"`
 	ReadOnly          bool             `json:"readOnly"`
 }
+
+type PromQLQuery struct {
+	Expression  string `json:"expr"`
+	ProjectName string `json:"projectName"`
+	Step        string `json:"step"`
+}


### PR DESCRIPTION
Update that allows us to use PromQL queries for either Prometheus or Google Cloud Monitoring data sources, as long as there's a promql target set up for the panel.