### PR TITLE
Feature/update descriptions clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.code-workspace
 grafctl
+backup-*.json

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ SUBCOMMANDS
   ls       List grafana dashboards
   inspect  Inspect grafana dashboard
   sync     sync grafana dashboards
+  export   export panel queries from grafana dashboard to filesystem
 ```
 
 ### Examples
@@ -69,6 +70,12 @@ $ grafctl -url {{grafana.url}} -key {{api-key}} import ./backup.json.gz
 
 # list dashboards
 $ grafctl -url {{grafana.url}} -key {{api-key}} dash ls
+
+# export panel queries from a dashboard
+$ grafctl -url {{grafana.url}} -key {{api-key}} dash export -uid {{dashboard-uid}} -queries ./queries
+
+# export panel queries and overwrite existing files
+$ grafctl -url {{grafana.url}} -key {{api-key}} dash export -uid {{dashboard-uid}} -queries ./queries -overwrite
 ```
 
 ## Contributing

--- a/pkg/command/client.go
+++ b/pkg/command/client.go
@@ -463,6 +463,8 @@ func (c *Client) UpdateDashboardDescriptions(ctx context.Context, uid string, ov
 		return fmt.Errorf("dashboard has no title")
 	}
 
+	c.logd("processing dashboard: %s (overwrite: %v, dryRun: %v)", dashboardTitle, overwrite, dryRun)
+
 	// Create backup if not dry run
 	if !dryRun {
 		backupName := fmt.Sprintf("backup-%s-%d.json", uid, time.Now().Unix())
@@ -479,6 +481,10 @@ func (c *Client) UpdateDashboardDescriptions(ctx context.Context, uid string, ov
 
 	panelsUpdated := 0
 	panelsSkipped := 0
+
+	// Get all panels
+	panels := dashboardFull.Dashboard.Get("panels").MustArray()
+	c.logd("found %d panels to process", len(panels))
 
 	// Process all panels
 	for _, panelBy := range dashboardFull.Dashboard.Get("panels").MustArray() {

--- a/pkg/command/client.go
+++ b/pkg/command/client.go
@@ -265,6 +265,131 @@ func (c *Client) updatePanelTargets(queryManager *QueryManager, panel *simplejso
 	return nil
 }
 
+func (c *Client) ExportDashboard(ctx context.Context, uid string, queriesDir string, overwrite bool) error {
+	dashboardFull, err := c.GetDashboardByUID(ctx, uid)
+	if err != nil {
+		return err
+	}
+
+	// Always create queries subdirectory
+	queriesSubdir := filepath.Join(queriesDir, "queries")
+	if err := os.MkdirAll(queriesSubdir, 0755); err != nil {
+		return err
+	}
+
+	// Iterate through all panels and export their queries
+	for _, panelBy := range dashboardFull.Dashboard.Get("panels").MustArray() {
+		panel := simplejson.NewFromAny(panelBy)
+		if err := c.exportPanelQueries(panel, queriesSubdir, overwrite); err != nil {
+			return err
+		}
+		// Handle sub-panels in row panels (older versions)
+		for _, subPanelBy := range panel.Get("panels").MustArray() {
+			if err := c.exportPanelQueries(simplejson.NewFromAny(subPanelBy), queriesSubdir, overwrite); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *Client) exportPanelQueries(panel *simplejson.Json, queriesDir string, overwrite bool) error {
+	panelType := panel.Get("type").MustString()
+	panelTitle := panel.Get("title").MustString()
+	panelDesc := panel.Get("description").MustString()
+	datasource := panel.Get("datasource").Get("type").MustString()
+
+	if panelDesc == "" {
+		c.logd("no description found for panel %s:%q", panelType, panelTitle)
+		return nil
+	}
+
+	targetsBy := panel.Get("targets").MustArray()
+	if len(targetsBy) <= 0 {
+		c.logd("no targets found for panel %s:%q", panelType, panelTitle)
+		return nil
+	}
+
+	// Parse panel description to get query file paths
+	queryPaths := []string{}
+	for _, part := range strings.Split(panelDesc, "\n") {
+		queryParts := strings.Split(part, "query=")
+		if len(queryParts) != 2 {
+			continue
+		}
+		queryPaths = append(queryPaths, queryParts[1])
+	}
+
+	if len(targetsBy) != len(queryPaths) {
+		c.logd("found %d query path(s) but only has %d target(s) for panel %s:%q", len(queryPaths), len(targetsBy), panelType, panelTitle)
+		return nil
+	}
+
+	// Export each target to its corresponding query file
+	for i, queryPath := range queryPaths {
+		target := simplejson.NewFromAny(targetsBy[i])
+		if err := c.exportTargetToFile(target, datasource, queryPath, queriesDir, overwrite); err != nil {
+			return err
+		}
+		c.logd("query exported: [%s:%s] query[%d] %s", panelType, panelTitle, i, queryPath)
+	}
+
+	return nil
+}
+
+func (c *Client) exportTargetToFile(target *simplejson.Json, datasource string, queryPath string, queriesDir string, overwrite bool) error {
+	var queryContent string
+	var fileExtension string
+
+	switch datasource {
+	case dataSourceTypePrometheus:
+		queryContent = target.Get("expr").MustString()
+		fileExtension = ".promql"
+	case dataSourceTypeStackDriver:
+		promqlQuery := target.Get("promQLQuery")
+		if promqlQuery != nil {
+			queryContent = promqlQuery.Get("expr").MustString()
+		} else {
+			queryContent = target.Get("expr").MustString()
+		}
+		fileExtension = ".promql"
+	default:
+		// Treat all other datasources as SQL
+		queryContent = target.Get("rawSql").MustString()
+		fileExtension = ".sql"
+	}
+
+	if queryContent == "" {
+		c.logd("no query content found for datasource %s (path: %s, extension: %s)", datasource, queryPath, fileExtension)
+		return nil
+	}
+
+	// Always write to queries subdirectory
+	fullPath := filepath.Join(queriesDir, queryPath+fileExtension)
+
+	// Check if file exists and skip if overwrite is false
+	if !overwrite {
+		if _, err := os.Stat(fullPath); err == nil {
+			c.logd("skipping existing file: %s", fullPath)
+			return nil
+		}
+	}
+
+	// Create directory if it doesn't exist
+	dir := filepath.Dir(fullPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	// Write the query to file
+	if err := os.WriteFile(fullPath, []byte(queryContent), 0644); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (c *Client) logd(format string, args ...interface{}) {
 	if !c.verbose {
 		return

--- a/pkg/command/client.go
+++ b/pkg/command/client.go
@@ -598,12 +598,12 @@ func (c *Client) sanitizeTitle(title string) string {
 	// Convert to lowercase
 	title = strings.ToLower(title)
 
-	// Replace spaces and special characters with underscores
+	// Replace spaces and special characters with hyphens
 	reg := regexp.MustCompile(`[^a-z0-9]+`)
-	title = reg.ReplaceAllString(title, "_")
+	title = reg.ReplaceAllString(title, "-")
 
-	// Remove leading/trailing underscores
-	title = strings.Trim(title, "_")
+	// Remove leading/trailing hyphens
+	title = strings.Trim(title, "-")
 
 	// Ensure it's not empty
 	if title == "" {

--- a/pkg/command/client.go
+++ b/pkg/command/client.go
@@ -619,7 +619,7 @@ func (c *Client) getPanelTypePrefix(panelType string) string {
 		"table":      "table",
 		"graph":      "graph",
 		"stat":       "stat",
-		"timeseries": "timeseries",
+		"timeseries": "graph",
 		"heatmap":    "heatmap",
 		"barchart":   "barchart",
 		"piechart":   "piechart",

--- a/pkg/command/dashboard.go
+++ b/pkg/command/dashboard.go
@@ -40,6 +40,7 @@ func NewDashboardCmd(rootConf *RootConfig) *DashboardCmd {
 			NewDashboardLsCmd(&conf).Command,
 			NewDashboardInspectCmd(&conf).Command,
 			NewDashboardSyncCmd(&conf).Command,
+			NewDashboardExportCmd(&conf).Command,
 		},
 	}
 	return &cmd

--- a/pkg/command/dashboard.go
+++ b/pkg/command/dashboard.go
@@ -41,6 +41,7 @@ func NewDashboardCmd(rootConf *RootConfig) *DashboardCmd {
 			NewDashboardInspectCmd(&conf).Command,
 			NewDashboardSyncCmd(&conf).Command,
 			NewDashboardExportCmd(&conf).Command,
+			NewDashboardUpdateDescriptionsCmd(&conf).Command,
 		},
 	}
 	return &cmd

--- a/pkg/command/dashboard_export.go
+++ b/pkg/command/dashboard_export.go
@@ -1,0 +1,74 @@
+package command
+
+import (
+	"context"
+	"flag"
+	"log"
+
+	"github.com/peterbourgon/ff/v2/ffcli"
+)
+
+// DashboardExportConfig has the config for the dashboardExport command and a reference to the root command config
+type DashboardExportConfig struct {
+	*DashboardConfig
+
+	UID        string
+	QueriesDir string
+	Overwrite  bool
+}
+
+// DashboardExportCmd wraps the dashboardExport config and a ffcli.Command
+type DashboardExportCmd struct {
+	Conf *DashboardExportConfig
+
+	*ffcli.Command
+}
+
+// NewDashboardExportCmd creates a new DashboardExportCmd
+func NewDashboardExportCmd(dashConf *DashboardConfig) *DashboardExportCmd {
+	conf := DashboardExportConfig{
+		DashboardConfig: dashConf,
+	}
+	cmd := DashboardExportCmd{
+		Conf: &conf,
+	}
+	fs := flag.NewFlagSet("grafctl dashboard export", flag.ExitOnError)
+	cmd.RegisterFlags(fs)
+
+	cmd.Command = &ffcli.Command{
+		Name:        "export",
+		ShortUsage:  "grafctl dash export",
+		ShortHelp:   "export panel queries from grafana dashboard to filesystem",
+		FlagSet:     fs,
+		Exec:        cmd.Exec,
+		Subcommands: []*ffcli.Command{},
+	}
+	return &cmd
+}
+
+// RegisterFlags registers a set of flags for the dashboardExport command
+func (c *DashboardExportCmd) RegisterFlags(fs *flag.FlagSet) {
+	fs.StringVar(&c.Conf.UID, "uid", "", "dashboard UID")
+	fs.StringVar(&c.Conf.QueriesDir, "queries", "", "base directory to save queries")
+	fs.BoolVar(&c.Conf.Overwrite, "overwrite", false, "overwrite existing query files")
+}
+
+// Exec executes the dashboard export command
+func (c *DashboardExportCmd) Exec(ctx context.Context, args []string) error {
+	if c.Conf.UID == "" {
+		log.Printf("missing -uid")
+		c.FlagSet.Usage()
+		return nil
+	}
+	if c.Conf.QueriesDir == "" {
+		log.Printf("missing -queries")
+		c.FlagSet.Usage()
+		return nil
+	}
+
+	if err := c.Conf.Client().ExportDashboard(ctx, c.Conf.UID, c.Conf.QueriesDir, c.Conf.Overwrite); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/command/dashboard_export_test.go
+++ b/pkg/command/dashboard_export_test.go
@@ -1,0 +1,142 @@
+package command
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/diogogmt/grafctl/pkg/grafsdk"
+	"github.com/diogogmt/grafctl/pkg/simplejson"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExportPanelQueriesOverwrite(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "grafctl-export-overwrite-test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Create a mock client
+	client := &Client{
+		Client:  &grafsdk.Client{},
+		apiURL:  "http://localhost:3000",
+		apiKey:  "test-key",
+		verbose: true,
+	}
+
+	// Create queries directory
+	queriesDir := filepath.Join(tempDir, "queries")
+	err = os.MkdirAll(queriesDir, 0755)
+	assert.NoError(t, err)
+
+	// Create an existing file with different content
+	existingFile := filepath.Join(queriesDir, "panel1.sql")
+	err = os.WriteFile(existingFile, []byte("EXISTING CONTENT"), 0644)
+	assert.NoError(t, err)
+
+	// Test SQL panel with overwrite=false (should skip existing file)
+	sqlPanel := createMockSQLPanel()
+	err = client.exportPanelQueries(sqlPanel, tempDir, false)
+	assert.NoError(t, err)
+
+	// Verify the existing file was not overwritten
+	content, err := os.ReadFile(existingFile)
+	assert.NoError(t, err)
+	assert.Equal(t, "EXISTING CONTENT", string(content))
+
+	// Test SQL panel with overwrite=true (should overwrite existing file)
+	err = client.exportPanelQueries(sqlPanel, tempDir, true)
+	assert.NoError(t, err)
+
+	// Verify the file was overwritten
+	content, err = os.ReadFile(existingFile)
+	assert.NoError(t, err)
+	assert.Equal(t, "SELECT * FROM test_table", string(content))
+}
+
+func TestExportPanelQueries(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "grafctl-export-test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Create a mock client
+	client := &Client{
+		Client:  &grafsdk.Client{},
+		apiURL:  "http://localhost:3000",
+		apiKey:  "test-key",
+		verbose: true,
+	}
+
+	// Test SQL panel
+	sqlPanel := createMockSQLPanel()
+	err = client.exportPanelQueries(sqlPanel, tempDir, true)
+	assert.NoError(t, err)
+
+	// Verify SQL file was created
+	sqlPath := filepath.Join(tempDir, "queries", "panel1.sql")
+	_, err = os.Stat(sqlPath)
+	assert.NoError(t, err)
+
+	sqlContent, err := os.ReadFile(sqlPath)
+	assert.NoError(t, err)
+	assert.Equal(t, "SELECT * FROM test_table", string(sqlContent))
+
+	// Test PromQL panel
+	promqlPanel := createMockPromQLPanel()
+	err = client.exportPanelQueries(promqlPanel, tempDir, true)
+	assert.NoError(t, err)
+
+	// Verify PromQL file was created
+	promqlPath := filepath.Join(tempDir, "queries", "panel2.promql")
+	_, err = os.Stat(promqlPath)
+	assert.NoError(t, err)
+
+	promqlContent, err := os.ReadFile(promqlPath)
+	assert.NoError(t, err)
+	assert.Equal(t, "up{job=\"test\"}", string(promqlContent))
+
+	// Debug: list all files under tempDir
+	fmt.Println("--- Debug: Listing files under tempDir ---")
+	filepath.Walk(tempDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			fmt.Printf("error: %v\n", err)
+			return nil
+		}
+		fmt.Println(path)
+		return nil
+	})
+}
+
+func createMockSQLPanel() *simplejson.Json {
+	panel := simplejson.New()
+	panel.Set("type", "stat")
+	panel.Set("title", "Test Panel 1")
+	panel.Set("description", "query=queries/panel1")
+
+	datasource := map[string]interface{}{"type": "postgres"}
+	panel.Set("datasource", datasource)
+
+	target := map[string]interface{}{"rawSql": "SELECT * FROM test_table"}
+	targets := []interface{}{target}
+	panel.Set("targets", targets)
+
+	return panel
+}
+
+func createMockPromQLPanel() *simplejson.Json {
+	panel := simplejson.New()
+	panel.Set("type", "graph")
+	panel.Set("title", "Test Panel 2")
+	panel.Set("description", "query=queries/panel2")
+
+	datasource := map[string]interface{}{"type": "prometheus"}
+	panel.Set("datasource", datasource)
+
+	target := map[string]interface{}{"expr": "up{job=\"test\"}"}
+	targets := []interface{}{target}
+	panel.Set("targets", targets)
+
+	return panel
+}

--- a/pkg/command/dashboard_update_descriptions.go
+++ b/pkg/command/dashboard_update_descriptions.go
@@ -1,0 +1,69 @@
+package command
+
+import (
+	"context"
+	"flag"
+	"log"
+
+	"github.com/peterbourgon/ff/v2/ffcli"
+)
+
+// DashboardUpdateDescriptionsConfig has the config for the dashboardUpdateDescriptions command
+type DashboardUpdateDescriptionsConfig struct {
+	*DashboardConfig
+
+	UID       string
+	Overwrite bool
+	DryRun    bool
+}
+
+// DashboardUpdateDescriptionsCmd wraps the dashboardUpdateDescriptions config and a ffcli.Command
+type DashboardUpdateDescriptionsCmd struct {
+	Conf *DashboardUpdateDescriptionsConfig
+
+	*ffcli.Command
+}
+
+// NewDashboardUpdateDescriptionsCmd creates a new DashboardUpdateDescriptionsCmd
+func NewDashboardUpdateDescriptionsCmd(dashConf *DashboardConfig) *DashboardUpdateDescriptionsCmd {
+	conf := DashboardUpdateDescriptionsConfig{
+		DashboardConfig: dashConf,
+	}
+	cmd := DashboardUpdateDescriptionsCmd{
+		Conf: &conf,
+	}
+	fs := flag.NewFlagSet("grafctl dashboard update-descriptions", flag.ExitOnError)
+	cmd.RegisterFlags(fs)
+
+	cmd.Command = &ffcli.Command{
+		Name:        "update-descriptions",
+		ShortUsage:  "grafctl dash update-descriptions",
+		ShortHelp:   "update panel descriptions with proper query paths",
+		FlagSet:     fs,
+		Exec:        cmd.Exec,
+		Subcommands: []*ffcli.Command{},
+	}
+	return &cmd
+}
+
+// RegisterFlags registers a set of flags for the dashboardUpdateDescriptions command
+func (c *DashboardUpdateDescriptionsCmd) RegisterFlags(fs *flag.FlagSet) {
+	fs.StringVar(&c.Conf.UID, "uid", "", "dashboard UID")
+	fs.BoolVar(&c.Conf.Overwrite, "overwrite", false, "update all panels (not just invalid ones)")
+	fs.BoolVar(&c.Conf.DryRun, "dry-run", false, "preview changes without updating dashboard")
+}
+
+// Exec executes the dashboard update-descriptions command
+func (c *DashboardUpdateDescriptionsCmd) Exec(ctx context.Context, args []string) error {
+	if c.Conf.UID == "" {
+		log.Printf("missing -uid")
+		c.FlagSet.Usage()
+		return nil
+	}
+
+	if err := c.Conf.Client().UpdateDashboardDescriptions(ctx, c.Conf.UID, c.Conf.Overwrite, c.Conf.DryRun); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/command/dashboard_update_descriptions_test.go
+++ b/pkg/command/dashboard_update_descriptions_test.go
@@ -16,15 +16,15 @@ func TestSanitizeTitle(t *testing.T) {
 		verbose: true,
 	}
 
-	// Test basic sanitization
-	assert.Equal(t, "my_dashboard", client.sanitizeTitle("My Dashboard"))
-	assert.Equal(t, "cpu_usage", client.sanitizeTitle("CPU Usage"))
-	assert.Equal(t, "api_requests_second", client.sanitizeTitle("API Requests/Second"))
-
+		// Test basic sanitization
+	assert.Equal(t, "my-dashboard", client.sanitizeTitle("My Dashboard"))
+	assert.Equal(t, "cpu-usage", client.sanitizeTitle("CPU Usage"))
+	assert.Equal(t, "api-requests-second", client.sanitizeTitle("API Requests/Second"))
+	
 	// Test special characters
-	assert.Equal(t, "test_panel", client.sanitizeTitle("Test Panel!"))
-	assert.Equal(t, "panel_123", client.sanitizeTitle("Panel 123"))
-	assert.Equal(t, "panel_with_dashes", client.sanitizeTitle("Panel-with-dashes"))
+	assert.Equal(t, "test-panel", client.sanitizeTitle("Test Panel!"))
+	assert.Equal(t, "panel-123", client.sanitizeTitle("Panel 123"))
+	assert.Equal(t, "panel-with-dashes", client.sanitizeTitle("Panel-with-dashes"))
 
 	// Test edge cases
 	assert.Equal(t, "untitled", client.sanitizeTitle(""))
@@ -60,17 +60,17 @@ func TestGeneratePanelDescription(t *testing.T) {
 		verbose: true,
 	}
 
-	// Test panel without row
+		// Test panel without row
 	desc := client.generatePanelDescription("My Dashboard", "", "table", "CPU Usage")
-	assert.Equal(t, "query=my_dashboard/table-cpu_usage", desc)
-
+	assert.Equal(t, "query=my-dashboard/table-cpu-usage", desc)
+	
 	// Test panel with row
 	desc = client.generatePanelDescription("My Dashboard", "System Metrics", "graph", "Memory Usage")
-	assert.Equal(t, "query=my_dashboard/system_metrics/graph-memory_usage", desc)
-
+	assert.Equal(t, "query=my-dashboard/system-metrics/graph-memory-usage", desc)
+	
 	// Test with special characters
 	desc = client.generatePanelDescription("API Dashboard", "Request Stats", "stat", "Requests/Second!")
-	assert.Equal(t, "query=api_dashboard/request_stats/stat-requests_second", desc)
+	assert.Equal(t, "query=api-dashboard/request-stats/stat-requests-second", desc)
 }
 
 func TestIsInvalidDescription(t *testing.T) {
@@ -114,7 +114,7 @@ func TestUpdatePanelDescription(t *testing.T) {
 
 	// Check that description was updated
 	newDesc := panel.Get("description").MustString()
-	assert.Equal(t, "query=my_dashboard/table-test_panel", newDesc)
+	assert.Equal(t, "query=my-dashboard/table-test-panel", newDesc)
 
 	// Test dry run
 	panel.Set("description", "") // Reset

--- a/pkg/command/dashboard_update_descriptions_test.go
+++ b/pkg/command/dashboard_update_descriptions_test.go
@@ -16,11 +16,11 @@ func TestSanitizeTitle(t *testing.T) {
 		verbose: true,
 	}
 
-		// Test basic sanitization
+	// Test basic sanitization
 	assert.Equal(t, "my-dashboard", client.sanitizeTitle("My Dashboard"))
 	assert.Equal(t, "cpu-usage", client.sanitizeTitle("CPU Usage"))
 	assert.Equal(t, "api-requests-second", client.sanitizeTitle("API Requests/Second"))
-	
+
 	// Test special characters
 	assert.Equal(t, "test-panel", client.sanitizeTitle("Test Panel!"))
 	assert.Equal(t, "panel-123", client.sanitizeTitle("Panel 123"))
@@ -60,17 +60,25 @@ func TestGeneratePanelDescription(t *testing.T) {
 		verbose: true,
 	}
 
-		// Test panel without row
-	desc := client.generatePanelDescription("My Dashboard", "", "table", "CPU Usage")
-	assert.Equal(t, "query=my-dashboard/table-cpu-usage", desc)
-	
+	// Test panel without row
+	desc := client.generatePanelDescription("Business Metrics", "My Dashboard", "", "table", "CPU Usage")
+	assert.Equal(t, "query=business-metrics/my-dashboard/table-cpu-usage", desc)
+
 	// Test panel with row
-	desc = client.generatePanelDescription("My Dashboard", "System Metrics", "graph", "Memory Usage")
-	assert.Equal(t, "query=my-dashboard/system-metrics/graph-memory-usage", desc)
-	
+	desc = client.generatePanelDescription("Business Metrics", "My Dashboard", "System Metrics", "graph", "Memory Usage")
+	assert.Equal(t, "query=business-metrics/my-dashboard/system-metrics/graph-memory-usage", desc)
+
 	// Test with special characters
-	desc = client.generatePanelDescription("API Dashboard", "Request Stats", "stat", "Requests/Second!")
-	assert.Equal(t, "query=api-dashboard/request-stats/stat-requests-second", desc)
+	desc = client.generatePanelDescription("Business Metrics", "API Dashboard", "Request Stats", "stat", "Requests/Second!")
+	assert.Equal(t, "query=business-metrics/api-dashboard/request-stats/stat-requests-second", desc)
+
+	// Test with folder title
+	desc = client.generatePanelDescription("Business Metrics", "My Dashboard", "", "table", "CPU Usage")
+	assert.Equal(t, "query=business-metrics/my-dashboard/table-cpu-usage", desc)
+
+	// Test with folder title and row
+	desc = client.generatePanelDescription("Business Metrics", "My Dashboard", "System Metrics", "graph", "Memory Usage")
+	assert.Equal(t, "query=business-metrics/my-dashboard/system-metrics/graph-memory-usage", desc)
 }
 
 func TestIsInvalidDescription(t *testing.T) {
@@ -107,18 +115,18 @@ func TestUpdatePanelDescription(t *testing.T) {
 	panel.Set("description", "") // Empty description
 
 	// Test updating invalid description
-	updated, skipped, err := client.updatePanelDescription(panel, "My Dashboard", "", false, false)
+	updated, skipped, err := client.updatePanelDescription(panel, "Business Metrics", "My Dashboard", "", false, false)
 	assert.NoError(t, err)
 	assert.True(t, updated)
 	assert.False(t, skipped)
 
 	// Check that description was updated
 	newDesc := panel.Get("description").MustString()
-	assert.Equal(t, "query=my-dashboard/table-test-panel", newDesc)
+	assert.Equal(t, "query=business-metrics/my-dashboard/table-test-panel", newDesc)
 
 	// Test dry run
 	panel.Set("description", "") // Reset
-	updated, skipped, err = client.updatePanelDescription(panel, "My Dashboard", "", false, true)
+	updated, skipped, err = client.updatePanelDescription(panel, "Business Metrics", "My Dashboard", "", false, true)
 	assert.NoError(t, err)
 	assert.True(t, updated)
 	assert.False(t, skipped)
@@ -129,14 +137,299 @@ func TestUpdatePanelDescription(t *testing.T) {
 
 	// Test skipping valid description
 	panel.Set("description", "query=valid/path")
-	updated, skipped, err = client.updatePanelDescription(panel, "My Dashboard", "", false, false)
+	updated, skipped, err = client.updatePanelDescription(panel, "Business Metrics", "My Dashboard", "", false, false)
 	assert.NoError(t, err)
 	assert.False(t, updated)
 	assert.True(t, skipped)
 
 	// Test overwrite flag
-	updated, skipped, err = client.updatePanelDescription(panel, "My Dashboard", "", true, false)
+	updated, skipped, err = client.updatePanelDescription(panel, "Business Metrics", "My Dashboard", "", true, false)
 	assert.NoError(t, err)
 	assert.True(t, updated)
 	assert.False(t, skipped)
+}
+
+func TestRowAssignmentLogic(t *testing.T) {
+
+	// Create a test dashboard with multiple rows and panels
+	dashboard := simplejson.New()
+	panels := []interface{}{
+		// Row 1 at Y=0
+		map[string]interface{}{
+			"id":    1,
+			"type":  "row",
+			"title": "First Row",
+			"gridPos": map[string]interface{}{
+				"y": 0,
+			},
+		},
+		// Panel A at Y=1 (should belong to First Row)
+		map[string]interface{}{
+			"id":    2,
+			"type":  "table",
+			"title": "Panel A",
+			"gridPos": map[string]interface{}{
+				"y": 1,
+			},
+		},
+		// Row 2 at Y=10
+		map[string]interface{}{
+			"id":    3,
+			"type":  "row",
+			"title": "Second Row",
+			"gridPos": map[string]interface{}{
+				"y": 10,
+			},
+		},
+		// Panel B at Y=11 (should belong to Second Row)
+		map[string]interface{}{
+			"id":    4,
+			"type":  "graph",
+			"title": "Panel B",
+			"gridPos": map[string]interface{}{
+				"y": 11,
+			},
+		},
+		// Panel C at Y=2 (should belong to First Row)
+		map[string]interface{}{
+			"id":    5,
+			"type":  "stat",
+			"title": "Panel C",
+			"gridPos": map[string]interface{}{
+				"y": 2,
+			},
+		},
+	}
+	dashboard.Set("panels", panels)
+
+	// Create mock dashboard metadata
+	meta := simplejson.New()
+	meta.Set("folderTitle", "Test Folder")
+
+	// Create mock dashboard with metadata
+	dashboardFull := &grafsdk.DashboardWithMeta{
+		Dashboard: dashboard,
+		Meta:      meta,
+	}
+
+	// Mock the GetDashboardByUID method by creating a test function
+	testUpdateDescriptions := func() error {
+		dashboardTitle := dashboardFull.Dashboard.Get("title").MustString()
+		if dashboardTitle == "" {
+			dashboardTitle = "Test Dashboard"
+		}
+
+		_ = dashboardFull.Meta.Get("folderTitle").MustString()
+
+		panels := dashboardFull.Dashboard.Get("panels").MustArray()
+
+		// First pass: collect row information
+		rowInfo := make(map[int]string) // panel ID -> row title
+
+		// Collect all rows first
+		var rows []struct {
+			title string
+			y     int
+		}
+		for _, panelBy := range panels {
+			panel := simplejson.NewFromAny(panelBy)
+			panelType := panel.Get("type").MustString()
+			if panelType == "row" {
+				rowTitle := panel.Get("title").MustString()
+				rowY := panel.Get("gridPos").Get("y").MustInt()
+				rows = append(rows, struct {
+					title string
+					y     int
+				}{title: rowTitle, y: rowY})
+			}
+		}
+
+		// For each non-row panel, find the closest row above it
+		for _, panelBy := range panels {
+			panel := simplejson.NewFromAny(panelBy)
+			panelType := panel.Get("type").MustString()
+			if panelType != "row" {
+				panelY := panel.Get("gridPos").Get("y").MustInt()
+				panelID := panel.Get("id").MustInt()
+
+				// Find the closest row above this panel
+				var closestRow string
+				var closestDistance int = -1
+
+				for _, row := range rows {
+					if panelY > row.y {
+						distance := panelY - row.y
+						if closestDistance == -1 || distance < closestDistance {
+							closestDistance = distance
+							closestRow = row.title
+						}
+					}
+				}
+
+				if closestRow != "" {
+					rowInfo[panelID] = closestRow
+				}
+			}
+		}
+
+		// Verify the assignments
+		assert.Equal(t, "First Row", rowInfo[2], "Panel A should belong to First Row")
+		assert.Equal(t, "Second Row", rowInfo[4], "Panel B should belong to Second Row")
+		assert.Equal(t, "First Row", rowInfo[5], "Panel C should belong to First Row")
+
+		return nil
+	}
+
+	err := testUpdateDescriptions()
+	assert.NoError(t, err)
+}
+
+func TestMixedPanelStructure(t *testing.T) {
+	// Create a test dashboard with mixed panel structure (nested + standalone)
+	dashboard := simplejson.New()
+	panels := []interface{}{
+		// Row 1 at Y=0 with nested panels
+		map[string]interface{}{
+			"id":    1,
+			"type":  "row",
+			"title": "First Row",
+			"gridPos": map[string]interface{}{
+				"y": 0,
+			},
+			"panels": []interface{}{
+				// Nested panel in First Row
+				map[string]interface{}{
+					"id":    2,
+					"type":  "table",
+					"title": "Nested Panel A",
+					"gridPos": map[string]interface{}{
+						"y": 1,
+					},
+				},
+			},
+		},
+		// Row 2 at Y=10 with empty panels array
+		map[string]interface{}{
+			"id":    3,
+			"type":  "row",
+			"title": "Second Row",
+			"gridPos": map[string]interface{}{
+				"y": 10,
+			},
+			"panels": []interface{}{}, // Empty - panels will be standalone
+		},
+		// Standalone panel at Y=11 (should belong to Second Row)
+		map[string]interface{}{
+			"id":    4,
+			"type":  "graph",
+			"title": "Standalone Panel B",
+			"gridPos": map[string]interface{}{
+				"y": 11,
+			},
+		},
+		// Another standalone panel at Y=12 (should belong to Second Row)
+		map[string]interface{}{
+			"id":    5,
+			"type":  "stat",
+			"title": "Standalone Panel C",
+			"gridPos": map[string]interface{}{
+				"y": 12,
+			},
+		},
+	}
+	dashboard.Set("panels", panels)
+
+	// Create mock dashboard metadata
+	meta := simplejson.New()
+	meta.Set("folderTitle", "Test Folder")
+
+	// Create mock dashboard with metadata
+	dashboardFull := &grafsdk.DashboardWithMeta{
+		Dashboard: dashboard,
+		Meta:      meta,
+	}
+
+	// Mock the row assignment logic
+	testRowAssignment := func() error {
+		panels := dashboardFull.Dashboard.Get("panels").MustArray()
+
+		// First pass: collect row information
+		rowInfo := make(map[int]string) // panel ID -> row title
+
+		// Collect all rows first
+		var rows []struct {
+			title string
+			y     int
+		}
+		for _, panelBy := range panels {
+			panel := simplejson.NewFromAny(panelBy)
+			panelType := panel.Get("type").MustString()
+			if panelType == "row" {
+				rowTitle := panel.Get("title").MustString()
+				rowY := panel.Get("gridPos").Get("y").MustInt()
+				rows = append(rows, struct {
+					title string
+					y     int
+				}{title: rowTitle, y: rowY})
+			}
+		}
+
+		// Handle nested panels within rows
+		for _, panelBy := range panels {
+			panel := simplejson.NewFromAny(panelBy)
+			panelType := panel.Get("type").MustString()
+			if panelType == "row" {
+				rowTitle := panel.Get("title").MustString()
+				// Process panels nested within this row
+				for _, subPanelBy := range panel.Get("panels").MustArray() {
+					subPanel := simplejson.NewFromAny(subPanelBy)
+					subPanelID := subPanel.Get("id").MustInt()
+					rowInfo[subPanelID] = rowTitle
+				}
+			}
+		}
+
+		// Handle standalone panels (not nested in rows) - find the closest row above them
+		for _, panelBy := range panels {
+			panel := simplejson.NewFromAny(panelBy)
+			panelType := panel.Get("type").MustString()
+			if panelType != "row" {
+				panelY := panel.Get("gridPos").Get("y").MustInt()
+				panelID := panel.Get("id").MustInt()
+
+				// Skip if this panel is already assigned to a row (nested panels)
+				if _, exists := rowInfo[panelID]; exists {
+					continue
+				}
+
+				// Find the closest row above this panel
+				var closestRow string
+				var closestDistance int = -1
+
+				for _, row := range rows {
+					if panelY > row.y {
+						distance := panelY - row.y
+						if closestDistance == -1 || distance < closestDistance {
+							closestDistance = distance
+							closestRow = row.title
+						}
+					}
+				}
+
+				if closestRow != "" {
+					rowInfo[panelID] = closestRow
+				}
+			}
+		}
+
+		// Verify the assignments
+		assert.Equal(t, "First Row", rowInfo[2], "Nested Panel A should belong to First Row")
+		assert.Equal(t, "Second Row", rowInfo[4], "Standalone Panel B should belong to Second Row")
+		assert.Equal(t, "Second Row", rowInfo[5], "Standalone Panel C should belong to Second Row")
+
+		return nil
+	}
+
+	err := testRowAssignment()
+	assert.NoError(t, err)
 }

--- a/pkg/command/dashboard_update_descriptions_test.go
+++ b/pkg/command/dashboard_update_descriptions_test.go
@@ -45,7 +45,7 @@ func TestGetPanelTypePrefix(t *testing.T) {
 	assert.Equal(t, "table", client.getPanelTypePrefix("table"))
 	assert.Equal(t, "graph", client.getPanelTypePrefix("graph"))
 	assert.Equal(t, "stat", client.getPanelTypePrefix("stat"))
-	assert.Equal(t, "timeseries", client.getPanelTypePrefix("timeseries"))
+	assert.Equal(t, "graph", client.getPanelTypePrefix("timeseries"))
 	assert.Equal(t, "heatmap", client.getPanelTypePrefix("heatmap"))
 
 	// Test unknown panel type

--- a/pkg/command/dashboard_update_descriptions_test.go
+++ b/pkg/command/dashboard_update_descriptions_test.go
@@ -1,0 +1,142 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/diogogmt/grafctl/pkg/grafsdk"
+	"github.com/diogogmt/grafctl/pkg/simplejson"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeTitle(t *testing.T) {
+	client := &Client{
+		Client:  &grafsdk.Client{},
+		apiURL:  "http://localhost:3000",
+		apiKey:  "test-key",
+		verbose: true,
+	}
+
+	// Test basic sanitization
+	assert.Equal(t, "my_dashboard", client.sanitizeTitle("My Dashboard"))
+	assert.Equal(t, "cpu_usage", client.sanitizeTitle("CPU Usage"))
+	assert.Equal(t, "api_requests_second", client.sanitizeTitle("API Requests/Second"))
+
+	// Test special characters
+	assert.Equal(t, "test_panel", client.sanitizeTitle("Test Panel!"))
+	assert.Equal(t, "panel_123", client.sanitizeTitle("Panel 123"))
+	assert.Equal(t, "panel_with_dashes", client.sanitizeTitle("Panel-with-dashes"))
+
+	// Test edge cases
+	assert.Equal(t, "untitled", client.sanitizeTitle(""))
+	assert.Equal(t, "untitled", client.sanitizeTitle("   "))
+	assert.Equal(t, "untitled", client.sanitizeTitle("!@#$%"))
+	assert.Equal(t, "a", client.sanitizeTitle("A"))
+}
+
+func TestGetPanelTypePrefix(t *testing.T) {
+	client := &Client{
+		Client:  &grafsdk.Client{},
+		apiURL:  "http://localhost:3000",
+		apiKey:  "test-key",
+		verbose: true,
+	}
+
+	// Test known panel types
+	assert.Equal(t, "table", client.getPanelTypePrefix("table"))
+	assert.Equal(t, "graph", client.getPanelTypePrefix("graph"))
+	assert.Equal(t, "stat", client.getPanelTypePrefix("stat"))
+	assert.Equal(t, "timeseries", client.getPanelTypePrefix("timeseries"))
+	assert.Equal(t, "heatmap", client.getPanelTypePrefix("heatmap"))
+
+	// Test unknown panel type
+	assert.Equal(t, "panel", client.getPanelTypePrefix("unknown_type"))
+}
+
+func TestGeneratePanelDescription(t *testing.T) {
+	client := &Client{
+		Client:  &grafsdk.Client{},
+		apiURL:  "http://localhost:3000",
+		apiKey:  "test-key",
+		verbose: true,
+	}
+
+	// Test panel without row
+	desc := client.generatePanelDescription("My Dashboard", "", "table", "CPU Usage")
+	assert.Equal(t, "query=my_dashboard/table-cpu_usage", desc)
+
+	// Test panel with row
+	desc = client.generatePanelDescription("My Dashboard", "System Metrics", "graph", "Memory Usage")
+	assert.Equal(t, "query=my_dashboard/system_metrics/graph-memory_usage", desc)
+
+	// Test with special characters
+	desc = client.generatePanelDescription("API Dashboard", "Request Stats", "stat", "Requests/Second!")
+	assert.Equal(t, "query=api_dashboard/request_stats/stat-requests_second", desc)
+}
+
+func TestIsInvalidDescription(t *testing.T) {
+	client := &Client{
+		Client:  &grafsdk.Client{},
+		apiURL:  "http://localhost:3000",
+		apiKey:  "test-key",
+		verbose: true,
+	}
+
+	// Test invalid descriptions
+	assert.True(t, client.isInvalidDescription(""))
+	assert.True(t, client.isInvalidDescription("query="))
+	assert.True(t, client.isInvalidDescription("query=  "))
+	assert.True(t, client.isInvalidDescription("some random text"))
+
+	// Test valid descriptions
+	assert.False(t, client.isInvalidDescription("query=valid/path"))
+	assert.False(t, client.isInvalidDescription("query=queries/panel1\nquery=queries/panel2"))
+}
+
+func TestUpdatePanelDescription(t *testing.T) {
+	client := &Client{
+		Client:  &grafsdk.Client{},
+		apiURL:  "http://localhost:3000",
+		apiKey:  "test-key",
+		verbose: true,
+	}
+
+	// Create a test panel
+	panel := simplejson.New()
+	panel.Set("type", "table")
+	panel.Set("title", "Test Panel")
+	panel.Set("description", "") // Empty description
+
+	// Test updating invalid description
+	updated, skipped, err := client.updatePanelDescription(panel, "My Dashboard", "", false, false)
+	assert.NoError(t, err)
+	assert.True(t, updated)
+	assert.False(t, skipped)
+
+	// Check that description was updated
+	newDesc := panel.Get("description").MustString()
+	assert.Equal(t, "query=my_dashboard/table-test_panel", newDesc)
+
+	// Test dry run
+	panel.Set("description", "") // Reset
+	updated, skipped, err = client.updatePanelDescription(panel, "My Dashboard", "", false, true)
+	assert.NoError(t, err)
+	assert.True(t, updated)
+	assert.False(t, skipped)
+
+	// Check that description was NOT updated in dry run
+	desc := panel.Get("description").MustString()
+	assert.Equal(t, "", desc)
+
+	// Test skipping valid description
+	panel.Set("description", "query=valid/path")
+	updated, skipped, err = client.updatePanelDescription(panel, "My Dashboard", "", false, false)
+	assert.NoError(t, err)
+	assert.False(t, updated)
+	assert.True(t, skipped)
+
+	// Test overwrite flag
+	updated, skipped, err = client.updatePanelDescription(panel, "My Dashboard", "", true, false)
+	assert.NoError(t, err)
+	assert.True(t, updated)
+	assert.False(t, skipped)
+}


### PR DESCRIPTION
##  Add `grafctl dash update-descriptions` Command

### What's Changed
- **New Command**: `grafctl dash update-descriptions`
- **Auto-generates panel descriptions** in the format:  
  `query={{dashboard-title}}/{{row-title}}/{{prefix}}-{{panel-title}}`
- **Prefix** is based on panel type (e.g., table, graph, stat, etc.)
- **Sanitizes** all titles: lowercased, spaces/special chars replaced with underscores
- **Row support**: If panel is not inside a row, omits the row part
- **Flags**:
  - `--overwrite`: update all panels, not just those with empty/invalid descriptions
  - `--dry-run`: preview changes, don’t update dashboard
- **Backup**: Always creates a backup before updating (unless dry-run)
- **Tests**: Added for sanitization, prefix mapping, and update logic

### Usage Example

```bash
# Preview changes (dry run)
grafctl dash update-descriptions -uid <dashboard-uid> --dry-run

# Update only invalid/empty descriptions
grafctl dash update-descriptions -uid <dashboard-uid>

# Overwrite all panel descriptions
grafctl dash update-descriptions -uid <dashboard-uid> --overwrite
```

### Testing
- ✅ All new and existing tests pass
- ✅ Command builds and runs as expected

---

This PR adds a robust, automated way to ensure all panel descriptions are consistent and query-ready!